### PR TITLE
Some InferenceGraph code streamlining

### DIFF
--- a/cmd/router/main_test.go
+++ b/cmd/router/main_test.go
@@ -71,9 +71,7 @@ func TestSimpleModelChainer(t *testing.T) {
 		},
 	}
 	jsonBytes, _ := json.Marshal(input)
-	result := make(chan []byte)
-	go routeStep("root", graphSpec.Nodes["root"], graphSpec, jsonBytes, result)
-	res := <-result
+	res, err := routeStep("root", graphSpec, jsonBytes)
 	var response map[string]interface{}
 	err = json.Unmarshal(res, &response)
 	fmt.Printf("%v", response)
@@ -138,9 +136,7 @@ func TestSimpleModelEnsemble(t *testing.T) {
 		},
 	}
 	jsonBytes, _ := json.Marshal(input)
-	result := make(chan []byte)
-	go routeStep("root", graphSpec.Nodes["root"], graphSpec, jsonBytes, result)
-	res := <-result
+	res, err := routeStep("root", graphSpec, jsonBytes)
 	var response map[string]interface{}
 	err = json.Unmarshal(res, &response)
 	fmt.Printf("final response:%v", response)


### PR DESCRIPTION
- Avoid unnecessary goroutine use
- Avoid most unnecessary unmarshal+remarshals
- Deduplicate logic between router types
- Handle async errors in ensemble case
- Don't require stepName to be set
- Return http error response when applicable
- Simplify pickupRoute func
- Fix incorrect log parameter syntax
- Add webhook validation for unique step names and inference targets

Signed-off-by: Nick Hill <nickhill@us.ibm.com>